### PR TITLE
[DPE-6575] Add microk8s testing

### DIFF
--- a/lib/charms/kafka/v0/client.py
+++ b/lib/charms/kafka/v0/client.py
@@ -77,7 +77,7 @@ import logging
 import time
 import sys
 from functools import cached_property
-from typing import Generator, List, Optional
+from typing import Generator, List, Optional, Any
 
 from kafka import KafkaAdminClient, KafkaConsumer, KafkaProducer
 from kafka.admin import NewTopic
@@ -183,6 +183,10 @@ class KafkaClient:
             auto_offset_reset="earliest",
             consumer_timeout_ms=15000,
         )
+
+    def describe_cluster(self) -> Any:
+        """Returns the cluster metadata."""
+        return self._admin_client.describe_cluster()
 
     def create_topic(self, topic: NewTopic) -> None:
         """Creates a new topic on the Kafka cluster.

--- a/poetry.lock
+++ b/poetry.lock
@@ -201,18 +201,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.36.7"
+version = "1.36.18"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "boto3-1.36.7-py3-none-any.whl", hash = "sha256:ab501f75557863e2d2c9fa731e4fe25c45f35e0d92ea0ee11a4eaa63929d3ede"},
-    {file = "boto3-1.36.7.tar.gz", hash = "sha256:ae98634efa7b47ced1b0d7342e2940b32639eee913f33ab406590b8ed55ee94b"},
+    {file = "boto3-1.36.18-py3-none-any.whl", hash = "sha256:084ff25af2d7bda3102d6367f5453e2e83f8cde1da73079ea144595b03cb9400"},
+    {file = "boto3-1.36.18.tar.gz", hash = "sha256:be8e32c34d7b103a64fafdd277fa1ec136733b4bbfc11dcfa597efa36a820b37"},
 ]
 
 [package.dependencies]
-botocore = ">=1.36.7,<1.37.0"
+botocore = ">=1.36.18,<1.37.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.11.0,<0.12.0"
 
@@ -221,14 +221,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.36.7"
+version = "1.36.18"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "botocore-1.36.7-py3-none-any.whl", hash = "sha256:a6c6772d777af2957ac9975207fac1ccc4ce101408b85e9b5e3c5ba0bb949102"},
-    {file = "botocore-1.36.7.tar.gz", hash = "sha256:9abc64bde5e7d8f814ea91d6fc0a8142511fc96427c19fe9209677c20a0c9e6e"},
+    {file = "botocore-1.36.18-py3-none-any.whl", hash = "sha256:7898d109affd9231c555e71fda88308c1da2db8d39e83d33eb8cb40ebf1ba82f"},
+    {file = "botocore-1.36.18.tar.gz", hash = "sha256:ddadafe460e91f11677720a2fcc3ea09c4abb914de2b000da7ba46b4c97da3d7"},
 ]
 
 [package.dependencies]
@@ -237,7 +237,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
 
 [package.extras]
-crt = ["awscrt (==0.23.4)"]
+crt = ["awscrt (==0.23.8)"]
 
 [[package]]
 name = "cachetools"
@@ -253,14 +253,14 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2024.12.14"
+version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
-    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
+    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
+    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
 ]
 
 [[package]]
@@ -463,14 +463,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "codespell"
-version = "2.4.0"
+version = "2.4.1"
 description = "Fix common misspellings in text files"
 optional = false
 python-versions = ">=3.8"
 groups = ["lint"]
 files = [
-    {file = "codespell-2.4.0-py3-none-any.whl", hash = "sha256:b4c5b779f747dd481587aeecb5773301183f52b94b96ed51a28126d0482eec1d"},
-    {file = "codespell-2.4.0.tar.gz", hash = "sha256:587d45b14707fb8ce51339ba4cce50ae0e98ce228ef61f3c5e160e34f681be58"},
+    {file = "codespell-2.4.1-py3-none-any.whl", hash = "sha256:3dadafa67df7e4a3dbf51e0d7315061b80d265f9552ebd699b3dd6834b47e425"},
+    {file = "codespell-2.4.1.tar.gz", hash = "sha256:299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5"},
 ]
 
 [package.extras]
@@ -514,74 +514,75 @@ typing-extensions = "*"
 
 [[package]]
 name = "coverage"
-version = "7.6.10"
+version = "7.6.12"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["unit"]
 files = [
-    {file = "coverage-7.6.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c912978f7fbf47ef99cec50c4401340436d200d41d714c7a4766f377c5b7b78"},
-    {file = "coverage-7.6.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a01ec4af7dfeb96ff0078ad9a48810bb0cc8abcb0115180c6013a6b26237626c"},
-    {file = "coverage-7.6.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3b204c11e2b2d883946fe1d97f89403aa1811df28ce0447439178cc7463448a"},
-    {file = "coverage-7.6.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32ee6d8491fcfc82652a37109f69dee9a830e9379166cb73c16d8dc5c2915165"},
-    {file = "coverage-7.6.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675cefc4c06e3b4c876b85bfb7c59c5e2218167bbd4da5075cbe3b5790a28988"},
-    {file = "coverage-7.6.10-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5"},
-    {file = "coverage-7.6.10-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4eea95ef275de7abaef630c9b2c002ffbc01918b726a39f5a4353916ec72d2f3"},
-    {file = "coverage-7.6.10-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e2f0280519e42b0a17550072861e0bc8a80a0870de260f9796157d3fca2733c5"},
-    {file = "coverage-7.6.10-cp310-cp310-win32.whl", hash = "sha256:bc67deb76bc3717f22e765ab3e07ee9c7a5e26b9019ca19a3b063d9f4b874244"},
-    {file = "coverage-7.6.10-cp310-cp310-win_amd64.whl", hash = "sha256:0f460286cb94036455e703c66988851d970fdfd8acc2a1122ab7f4f904e4029e"},
-    {file = "coverage-7.6.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ea3c8f04b3e4af80e17bab607c386a830ffc2fb88a5484e1df756478cf70d1d3"},
-    {file = "coverage-7.6.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:507a20fc863cae1d5720797761b42d2d87a04b3e5aeb682ef3b7332e90598f43"},
-    {file = "coverage-7.6.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d37a84878285b903c0fe21ac8794c6dab58150e9359f1aaebbeddd6412d53132"},
-    {file = "coverage-7.6.10-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a534738b47b0de1995f85f582d983d94031dffb48ab86c95bdf88dc62212142f"},
-    {file = "coverage-7.6.10-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d7a2bf79378d8fb8afaa994f91bfd8215134f8631d27eba3e0e2c13546ce994"},
-    {file = "coverage-7.6.10-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6713ba4b4ebc330f3def51df1d5d38fad60b66720948112f114968feb52d3f99"},
-    {file = "coverage-7.6.10-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ab32947f481f7e8c763fa2c92fd9f44eeb143e7610c4ca9ecd6a36adab4081bd"},
-    {file = "coverage-7.6.10-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7bbd8c8f1b115b892e34ba66a097b915d3871db7ce0e6b9901f462ff3a975377"},
-    {file = "coverage-7.6.10-cp311-cp311-win32.whl", hash = "sha256:299e91b274c5c9cdb64cbdf1b3e4a8fe538a7a86acdd08fae52301b28ba297f8"},
-    {file = "coverage-7.6.10-cp311-cp311-win_amd64.whl", hash = "sha256:489a01f94aa581dbd961f306e37d75d4ba16104bbfa2b0edb21d29b73be83609"},
-    {file = "coverage-7.6.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27c6e64726b307782fa5cbe531e7647aee385a29b2107cd87ba7c0105a5d3853"},
-    {file = "coverage-7.6.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c56e097019e72c373bae32d946ecf9858fda841e48d82df7e81c63ac25554078"},
-    {file = "coverage-7.6.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7827a5bc7bdb197b9e066cdf650b2887597ad124dd99777332776f7b7c7d0d0"},
-    {file = "coverage-7.6.10-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204a8238afe787323a8b47d8be4df89772d5c1e4651b9ffa808552bdf20e1d50"},
-    {file = "coverage-7.6.10-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67926f51821b8e9deb6426ff3164870976fe414d033ad90ea75e7ed0c2e5022"},
-    {file = "coverage-7.6.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e78b270eadb5702938c3dbe9367f878249b5ef9a2fcc5360ac7bff694310d17b"},
-    {file = "coverage-7.6.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:714f942b9c15c3a7a5fe6876ce30af831c2ad4ce902410b7466b662358c852c0"},
-    {file = "coverage-7.6.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:abb02e2f5a3187b2ac4cd46b8ced85a0858230b577ccb2c62c81482ca7d18852"},
-    {file = "coverage-7.6.10-cp312-cp312-win32.whl", hash = "sha256:55b201b97286cf61f5e76063f9e2a1d8d2972fc2fcfd2c1272530172fd28c359"},
-    {file = "coverage-7.6.10-cp312-cp312-win_amd64.whl", hash = "sha256:e4ae5ac5e0d1e4edfc9b4b57b4cbecd5bc266a6915c500f358817a8496739247"},
-    {file = "coverage-7.6.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9"},
-    {file = "coverage-7.6.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e80eba8801c386f72e0712a0453431259c45c3249f0009aff537a517b52942b"},
-    {file = "coverage-7.6.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a372c89c939d57abe09e08c0578c1d212e7a678135d53aa16eec4430adc5e690"},
-    {file = "coverage-7.6.10-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ec22b5e7fe7a0fa8509181c4aac1db48f3dd4d3a566131b313d1efc102892c18"},
-    {file = "coverage-7.6.10-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26bcf5c4df41cad1b19c84af71c22cbc9ea9a547fc973f1f2cc9a290002c8b3c"},
-    {file = "coverage-7.6.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e4630c26b6084c9b3cb53b15bd488f30ceb50b73c35c5ad7871b869cb7365fd"},
-    {file = "coverage-7.6.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2396e8116db77789f819d2bc8a7e200232b7a282c66e0ae2d2cd84581a89757e"},
-    {file = "coverage-7.6.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:79109c70cc0882e4d2d002fe69a24aa504dec0cc17169b3c7f41a1d341a73694"},
-    {file = "coverage-7.6.10-cp313-cp313-win32.whl", hash = "sha256:9e1747bab246d6ff2c4f28b4d186b205adced9f7bd9dc362051cc37c4a0c7bd6"},
-    {file = "coverage-7.6.10-cp313-cp313-win_amd64.whl", hash = "sha256:254f1a3b1eef5f7ed23ef265eaa89c65c8c5b6b257327c149db1ca9d4a35f25e"},
-    {file = "coverage-7.6.10-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2ccf240eb719789cedbb9fd1338055de2761088202a9a0b73032857e53f612fe"},
-    {file = "coverage-7.6.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0c807ca74d5a5e64427c8805de15b9ca140bba13572d6d74e262f46f50b13273"},
-    {file = "coverage-7.6.10-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bcfa46d7709b5a7ffe089075799b902020b62e7ee56ebaed2f4bdac04c508d8"},
-    {file = "coverage-7.6.10-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e0de1e902669dccbf80b0415fb6b43d27edca2fbd48c74da378923b05316098"},
-    {file = "coverage-7.6.10-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7b444c42bbc533aaae6b5a2166fd1a797cdb5eb58ee51a92bee1eb94a1e1cb"},
-    {file = "coverage-7.6.10-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b330368cb99ef72fcd2dc3ed260adf67b31499584dc8a20225e85bfe6f6cfed0"},
-    {file = "coverage-7.6.10-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9a7cfb50515f87f7ed30bc882f68812fd98bc2852957df69f3003d22a2aa0abf"},
-    {file = "coverage-7.6.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f93531882a5f68c28090f901b1d135de61b56331bba82028489bc51bdd818d2"},
-    {file = "coverage-7.6.10-cp313-cp313t-win32.whl", hash = "sha256:89d76815a26197c858f53c7f6a656686ec392b25991f9e409bcef020cd532312"},
-    {file = "coverage-7.6.10-cp313-cp313t-win_amd64.whl", hash = "sha256:54a5f0f43950a36312155dae55c505a76cd7f2b12d26abeebbe7a0b36dbc868d"},
-    {file = "coverage-7.6.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:656c82b8a0ead8bba147de9a89bda95064874c91a3ed43a00e687f23cc19d53a"},
-    {file = "coverage-7.6.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccc2b70a7ed475c68ceb548bf69cec1e27305c1c2606a5eb7c3afff56a1b3b27"},
-    {file = "coverage-7.6.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5e37dc41d57ceba70956fa2fc5b63c26dba863c946ace9705f8eca99daecdc4"},
-    {file = "coverage-7.6.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f"},
-    {file = "coverage-7.6.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa744da1820678b475e4ba3dfd994c321c5b13381d1041fe9c608620e6676e25"},
-    {file = "coverage-7.6.10-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c0b1818063dc9e9d838c09e3a473c1422f517889436dd980f5d721899e66f315"},
-    {file = "coverage-7.6.10-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:59af35558ba08b758aec4d56182b222976330ef8d2feacbb93964f576a7e7a90"},
-    {file = "coverage-7.6.10-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7ed2f37cfce1ce101e6dffdfd1c99e729dd2ffc291d02d3e2d0af8b53d13840d"},
-    {file = "coverage-7.6.10-cp39-cp39-win32.whl", hash = "sha256:4bcc276261505d82f0ad426870c3b12cb177752834a633e737ec5ee79bbdff18"},
-    {file = "coverage-7.6.10-cp39-cp39-win_amd64.whl", hash = "sha256:457574f4599d2b00f7f637a0700a6422243b3565509457b2dbd3f50703e11f59"},
-    {file = "coverage-7.6.10-pp39.pp310-none-any.whl", hash = "sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f"},
-    {file = "coverage-7.6.10.tar.gz", hash = "sha256:7fb105327c8f8f0682e29843e2ff96af9dcbe5bab8eeb4b398c6a33a16d80a23"},
+    {file = "coverage-7.6.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:704c8c8c6ce6569286ae9622e534b4f5b9759b6f2cd643f1c1a61f666d534fe8"},
+    {file = "coverage-7.6.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ad7525bf0241e5502168ae9c643a2f6c219fa0a283001cee4cf23a9b7da75879"},
+    {file = "coverage-7.6.12-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06097c7abfa611c91edb9e6920264e5be1d6ceb374efb4986f38b09eed4cb2fe"},
+    {file = "coverage-7.6.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:220fa6c0ad7d9caef57f2c8771918324563ef0d8272c94974717c3909664e674"},
+    {file = "coverage-7.6.12-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3688b99604a24492bcfe1c106278c45586eb819bf66a654d8a9a1433022fb2eb"},
+    {file = "coverage-7.6.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d1a987778b9c71da2fc8948e6f2656da6ef68f59298b7e9786849634c35d2c3c"},
+    {file = "coverage-7.6.12-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:cec6b9ce3bd2b7853d4a4563801292bfee40b030c05a3d29555fd2a8ee9bd68c"},
+    {file = "coverage-7.6.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ace9048de91293e467b44bce0f0381345078389814ff6e18dbac8fdbf896360e"},
+    {file = "coverage-7.6.12-cp310-cp310-win32.whl", hash = "sha256:ea31689f05043d520113e0552f039603c4dd71fa4c287b64cb3606140c66f425"},
+    {file = "coverage-7.6.12-cp310-cp310-win_amd64.whl", hash = "sha256:676f92141e3c5492d2a1596d52287d0d963df21bf5e55c8b03075a60e1ddf8aa"},
+    {file = "coverage-7.6.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e18aafdfb3e9ec0d261c942d35bd7c28d031c5855dadb491d2723ba54f4c3015"},
+    {file = "coverage-7.6.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66fe626fd7aa5982cdebad23e49e78ef7dbb3e3c2a5960a2b53632f1f703ea45"},
+    {file = "coverage-7.6.12-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ef01d70198431719af0b1f5dcbefc557d44a190e749004042927b2a3fed0702"},
+    {file = "coverage-7.6.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e92ae5a289a4bc4c0aae710c0948d3c7892e20fd3588224ebe242039573bf0"},
+    {file = "coverage-7.6.12-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e695df2c58ce526eeab11a2e915448d3eb76f75dffe338ea613c1201b33bab2f"},
+    {file = "coverage-7.6.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d74c08e9aaef995f8c4ef6d202dbd219c318450fe2a76da624f2ebb9c8ec5d9f"},
+    {file = "coverage-7.6.12-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e995b3b76ccedc27fe4f477b349b7d64597e53a43fc2961db9d3fbace085d69d"},
+    {file = "coverage-7.6.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b1f097878d74fe51e1ddd1be62d8e3682748875b461232cf4b52ddc6e6db0bba"},
+    {file = "coverage-7.6.12-cp311-cp311-win32.whl", hash = "sha256:1f7ffa05da41754e20512202c866d0ebfc440bba3b0ed15133070e20bf5aeb5f"},
+    {file = "coverage-7.6.12-cp311-cp311-win_amd64.whl", hash = "sha256:e216c5c45f89ef8971373fd1c5d8d1164b81f7f5f06bbf23c37e7908d19e8558"},
+    {file = "coverage-7.6.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b172f8e030e8ef247b3104902cc671e20df80163b60a203653150d2fc204d1ad"},
+    {file = "coverage-7.6.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:641dfe0ab73deb7069fb972d4d9725bf11c239c309ce694dd50b1473c0f641c3"},
+    {file = "coverage-7.6.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e549f54ac5f301e8e04c569dfdb907f7be71b06b88b5063ce9d6953d2d58574"},
+    {file = "coverage-7.6.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959244a17184515f8c52dcb65fb662808767c0bd233c1d8a166e7cf74c9ea985"},
+    {file = "coverage-7.6.12-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bda1c5f347550c359f841d6614fb8ca42ae5cb0b74d39f8a1e204815ebe25750"},
+    {file = "coverage-7.6.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1ceeb90c3eda1f2d8c4c578c14167dbd8c674ecd7d38e45647543f19839dd6ea"},
+    {file = "coverage-7.6.12-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f16f44025c06792e0fb09571ae454bcc7a3ec75eeb3c36b025eccf501b1a4c3"},
+    {file = "coverage-7.6.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b076e625396e787448d27a411aefff867db2bffac8ed04e8f7056b07024eed5a"},
+    {file = "coverage-7.6.12-cp312-cp312-win32.whl", hash = "sha256:00b2086892cf06c7c2d74983c9595dc511acca00665480b3ddff749ec4fb2a95"},
+    {file = "coverage-7.6.12-cp312-cp312-win_amd64.whl", hash = "sha256:7ae6eabf519bc7871ce117fb18bf14e0e343eeb96c377667e3e5dd12095e0288"},
+    {file = "coverage-7.6.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:488c27b3db0ebee97a830e6b5a3ea930c4a6e2c07f27a5e67e1b3532e76b9ef1"},
+    {file = "coverage-7.6.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d1095bbee1851269f79fd8e0c9b5544e4c00c0c24965e66d8cba2eb5bb535fd"},
+    {file = "coverage-7.6.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0533adc29adf6a69c1baa88c3d7dbcaadcffa21afbed3ca7a225a440e4744bf9"},
+    {file = "coverage-7.6.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53c56358d470fa507a2b6e67a68fd002364d23c83741dbc4c2e0680d80ca227e"},
+    {file = "coverage-7.6.12-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64cbb1a3027c79ca6310bf101014614f6e6e18c226474606cf725238cf5bc2d4"},
+    {file = "coverage-7.6.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79cac3390bfa9836bb795be377395f28410811c9066bc4eefd8015258a7578c6"},
+    {file = "coverage-7.6.12-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9b148068e881faa26d878ff63e79650e208e95cf1c22bd3f77c3ca7b1d9821a3"},
+    {file = "coverage-7.6.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8bec2ac5da793c2685ce5319ca9bcf4eee683b8a1679051f8e6ec04c4f2fd7dc"},
+    {file = "coverage-7.6.12-cp313-cp313-win32.whl", hash = "sha256:200e10beb6ddd7c3ded322a4186313d5ca9e63e33d8fab4faa67ef46d3460af3"},
+    {file = "coverage-7.6.12-cp313-cp313-win_amd64.whl", hash = "sha256:2b996819ced9f7dbb812c701485d58f261bef08f9b85304d41219b1496b591ef"},
+    {file = "coverage-7.6.12-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:299cf973a7abff87a30609879c10df0b3bfc33d021e1adabc29138a48888841e"},
+    {file = "coverage-7.6.12-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b467a8c56974bf06e543e69ad803c6865249d7a5ccf6980457ed2bc50312703"},
+    {file = "coverage-7.6.12-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2458f275944db8129f95d91aee32c828a408481ecde3b30af31d552c2ce284a0"},
+    {file = "coverage-7.6.12-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a9d8be07fb0832636a0f72b80d2a652fe665e80e720301fb22b191c3434d924"},
+    {file = "coverage-7.6.12-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14d47376a4f445e9743f6c83291e60adb1b127607a3618e3185bbc8091f0467b"},
+    {file = "coverage-7.6.12-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b95574d06aa9d2bd6e5cc35a5bbe35696342c96760b69dc4287dbd5abd4ad51d"},
+    {file = "coverage-7.6.12-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:ecea0c38c9079570163d663c0433a9af4094a60aafdca491c6a3d248c7432827"},
+    {file = "coverage-7.6.12-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2251fabcfee0a55a8578a9d29cecfee5f2de02f11530e7d5c5a05859aa85aee9"},
+    {file = "coverage-7.6.12-cp313-cp313t-win32.whl", hash = "sha256:eb5507795caabd9b2ae3f1adc95f67b1104971c22c624bb354232d65c4fc90b3"},
+    {file = "coverage-7.6.12-cp313-cp313t-win_amd64.whl", hash = "sha256:f60a297c3987c6c02ffb29effc70eadcbb412fe76947d394a1091a3615948e2f"},
+    {file = "coverage-7.6.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e7575ab65ca8399c8c4f9a7d61bbd2d204c8b8e447aab9d355682205c9dd948d"},
+    {file = "coverage-7.6.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8161d9fbc7e9fe2326de89cd0abb9f3599bccc1287db0aba285cb68d204ce929"},
+    {file = "coverage-7.6.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a1e465f398c713f1b212400b4e79a09829cd42aebd360362cd89c5bdc44eb87"},
+    {file = "coverage-7.6.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f25d8b92a4e31ff1bd873654ec367ae811b3a943583e05432ea29264782dc32c"},
+    {file = "coverage-7.6.12-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a936309a65cc5ca80fa9f20a442ff9e2d06927ec9a4f54bcba9c14c066323f2"},
+    {file = "coverage-7.6.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:aa6f302a3a0b5f240ee201297fff0bbfe2fa0d415a94aeb257d8b461032389bd"},
+    {file = "coverage-7.6.12-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f973643ef532d4f9be71dd88cf7588936685fdb576d93a79fe9f65bc337d9d73"},
+    {file = "coverage-7.6.12-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:78f5243bb6b1060aed6213d5107744c19f9571ec76d54c99cc15938eb69e0e86"},
+    {file = "coverage-7.6.12-cp39-cp39-win32.whl", hash = "sha256:69e62c5034291c845fc4df7f8155e8544178b6c774f97a99e2734b05eb5bed31"},
+    {file = "coverage-7.6.12-cp39-cp39-win_amd64.whl", hash = "sha256:b01a840ecc25dce235ae4c1b6a0daefb2a203dba0e6e980637ee9c2f6ee0df57"},
+    {file = "coverage-7.6.12-pp39.pp310-none-any.whl", hash = "sha256:7e39e845c4d764208e7b8f6a21c541ade741e2c41afabdfa1caa28687a3c98cf"},
+    {file = "coverage-7.6.12-py3-none-any.whl", hash = "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953"},
+    {file = "coverage-7.6.12.tar.gz", hash = "sha256:48cfc4641d95d34766ad41d9573cc0f22a48aa88d22657a1fe01dca0dbae4de2"},
 ]
 
 [package.dependencies]
@@ -685,14 +686,14 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastapi"
-version = "0.115.7"
+version = "0.115.8"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.115.7-py3-none-any.whl", hash = "sha256:eb6a8c8bf7f26009e8147111ff15b5177a0e19bb4a45bc3486ab14804539d21e"},
-    {file = "fastapi-0.115.7.tar.gz", hash = "sha256:0f106da6c01d88a6786b3248fb4d7a940d071f6f488488898ad5d354b25ed015"},
+    {file = "fastapi-0.115.8-py3-none-any.whl", hash = "sha256:753a96dd7e036b34eeef8babdfcfe3f28ff79648f86551eb36bfc1b0bf4a8cbf"},
+    {file = "fastapi-0.115.8.tar.gz", hash = "sha256:0ce9111231720190473e222cdf0f07f7206ad7e53ea02beb1d2dc36e2f0741e9"},
 ]
 
 [package.dependencies]
@@ -852,14 +853,14 @@ tomli = {version = "*", markers = "python_version > \"3.6\" and python_version <
 
 [[package]]
 name = "ipython"
-version = "8.31.0"
+version = "8.32.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
 groups = ["integration"]
 files = [
-    {file = "ipython-8.31.0-py3-none-any.whl", hash = "sha256:46ec58f8d3d076a61d128fe517a51eb730e3aaf0c184ea8c17d16e366660c6a6"},
-    {file = "ipython-8.31.0.tar.gz", hash = "sha256:b6a2274606bec6166405ff05e54932ed6e5cfecaca1fc05f2cacde7bb074d70b"},
+    {file = "ipython-8.32.0-py3-none-any.whl", hash = "sha256:cae85b0c61eff1fc48b0a8002de5958b6528fa9c8defb1894da63f42613708aa"},
+    {file = "ipython-8.32.0.tar.gz", hash = "sha256:be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251"},
 ]
 
 [package.dependencies]
@@ -1230,14 +1231,14 @@ signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 name = "ops"
-version = "2.17.1"
+version = "2.18.1"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "ops-2.17.1-py3-none-any.whl", hash = "sha256:0fabc45740d59619c3265328f51f71f99b06557e22493cdd32d10c2b25bcd553"},
-    {file = "ops-2.17.1.tar.gz", hash = "sha256:de2d1dd382b4a5f3df3ba78a5266d59462644f3f8ea0f4e7479a248998862a3f"},
+    {file = "ops-2.18.1-py3-none-any.whl", hash = "sha256:ba0312366e25b3ae90cf4b8d0af6ea6b612d4951500f856bce609cdb25c9bdeb"},
+    {file = "ops-2.18.1.tar.gz", hash = "sha256:5619deb370c00ea851f9579b780a09b88b1a1d020e58e1ed81d31c8fb7b28c8a"},
 ]
 
 [package.dependencies]
@@ -1245,7 +1246,7 @@ PyYAML = "==6.*"
 websocket-client = "==1.*"
 
 [package.extras]
-docs = ["canonical-sphinx-extensions", "furo", "linkify-it-py", "myst-parser", "ops-scenario (>=7.0.5,<8)", "pyspelling", "sphinx (>=8.0.0,<8.1.0)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinx-tabs", "sphinxcontrib-jquery", "sphinxext-opengraph"]
+docs = ["canonical-sphinx-extensions", "furo", "linkify-it-py", "myst-parser", "pyspelling", "sphinx (>=8.0.0,<8.1.0)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinx-tabs", "sphinxcontrib-jquery", "sphinxext-opengraph"]
 testing = ["ops-scenario (>=7.0.5,<8)"]
 
 [[package]]
@@ -1289,14 +1290,14 @@ dev = ["jinja2"]
 
 [[package]]
 name = "paramiko"
-version = "3.5.0"
+version = "3.5.1"
 description = "SSH2 protocol library"
 optional = false
 python-versions = ">=3.6"
 groups = ["integration"]
 files = [
-    {file = "paramiko-3.5.0-py3-none-any.whl", hash = "sha256:1fedf06b085359051cd7d0d270cebe19e755a8a921cc2ddbfa647fb0cd7d68f9"},
-    {file = "paramiko-3.5.0.tar.gz", hash = "sha256:ad11e540da4f55cedda52931f1a3f812a8238a7af7f62a60de538cd80bb28124"},
+    {file = "paramiko-3.5.1-py3-none-any.whl", hash = "sha256:43b9a0501fc2b5e70680388d9346cf252cfb7d00b0667c39e80eb43a408b8f61"},
+    {file = "paramiko-3.5.1.tar.gz", hash = "sha256:b2c665bc45b2b215bd7d7f039901b14b067da00f3a11e6640995fd58f2664822"},
 ]
 
 [package.dependencies]
@@ -1647,14 +1648,14 @@ pytz = "*"
 
 [[package]]
 name = "pyright"
-version = "1.1.392.post0"
+version = "1.1.394"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 groups = ["format", "lint"]
 files = [
-    {file = "pyright-1.1.392.post0-py3-none-any.whl", hash = "sha256:252f84458a46fa2f0fd4e2f91fc74f50b9ca52c757062e93f6c250c0d8329eb2"},
-    {file = "pyright-1.1.392.post0.tar.gz", hash = "sha256:3b7f88de74a28dcfa90c7d90c782b6569a48c2be5f9d4add38472bdaac247ebd"},
+    {file = "pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb"},
+    {file = "pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608"},
 ]
 
 [package.dependencies]
@@ -1823,14 +1824,14 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2024.2"
+version = "2025.1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["integration"]
 files = [
-    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
-    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
+    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
 ]
 
 [[package]]

--- a/src/charm.py
+++ b/src/charm.py
@@ -438,9 +438,9 @@ class KafkaConfigManager(ConfigManager):
         # We may be sitting behind k8s, in this case, we need to do a more careful calculation
         # of the host count, and hence, the replication factor
         if client and client.describe_cluster():
-            replication_factor = len(client.describe_cluster().get("brokers", 1)) - 1
+            replication_factor = len(client.describe_cluster().get("brokers", []))
         if replication_factor >= 1:
-            client.replication_factor = replication_factor - 1
+            client.replication_factor = min(replication_factor - 1, 3)
         return client
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -425,7 +425,7 @@ class KafkaConfigManager(ConfigManager):
             )
 
         host_count = len(state.hosts) if state.hosts else 1
-        return KafkaClient(
+        client = KafkaClient(
             servers=state.hosts or [],
             username=state.username,
             password=state.password,
@@ -434,6 +434,14 @@ class KafkaConfigManager(ConfigManager):
             certfile_path=None,
             replication_factor=host_count - 1,
         )
+
+        # We may be sitting behind k8s, in this case, we need to do a more careful calculation
+        # of the host count, and hence, the replication factor
+        if client and client.describe_cluster():
+            replication_factor = len(client.describe_cluster().get("brokers", 1)) - 1
+        if replication_factor >= 1:
+            client.replication_factor = replication_factor - 1
+        return client
 
 
 class KafkaBenchmarkActionsHandler(ActionsHandler):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,12 +3,15 @@
 # See LICENSE file for licensing details.
 
 
+import pathlib
 import subprocess
+from types import SimpleNamespace
 
 import juju
 import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from .helpers import (
     K8S_DB_MODEL_NAME,
@@ -43,3 +46,48 @@ async def kafka_benchmark_charm(ops_test: OpsTest):
     """Kafka charm used for integration testing."""
     charm = await ops_test.build_charm(".")
     return charm
+
+
+@pytest.fixture(scope="module")
+async def microk8s(ops_test: OpsTest) -> SimpleNamespace:
+    controller = yaml.safe_load(subprocess.check_output(["juju", "show-controller"]))
+
+    for controller_name in controller.keys():
+        # controller_data = details["details"]
+        try:
+            subprocess.run(["sudo", "snap", "install", "--classic", "microk8s"], check=True)
+            subprocess.run(["sudo", "snap", "install", "--classic", "kubectl"], check=True)
+            subprocess.run(["sudo", "microk8s", "enable", "dns", "hostpath-storage"], check=True)
+
+            # Configure kubectl now
+            subprocess.run(["mkdir", "-p", str(pathlib.Path.home() / ".kube")], check=True)
+            kubeconfig = subprocess.check_output(["sudo", "microk8s", "config"])
+            with open(str(pathlib.Path.home() / ".kube" / "config"), "w") as f:
+                f.write(kubeconfig.decode())
+            for attempt in Retrying(stop=stop_after_delay(150), wait=wait_fixed(15)):
+                with attempt:
+                    if (
+                        len(
+                            subprocess.check_output(
+                                "kubectl get po -A  --field-selector=status.phase!=Running",
+                                shell=True,
+                                stderr=subprocess.DEVNULL,
+                            ).decode()
+                        )
+                        != 0
+                    ):  # We got sth different than "No resources found." in stderr
+                        raise Exception()
+
+            # Get controller name
+            ctlname = controller_name
+
+            # Add microk8s to the kubeconfig
+            subprocess.run(
+                ["juju", "add-k8s", MICROK8S_CLOUD_NAME, "--client", "--controller", ctlname],
+                check=True,
+            )
+
+        except subprocess.CalledProcessError as e:
+            pytest.exit(str(e))
+
+    return SimpleNamespace(cloud_name=MICROK8S_CLOUD_NAME)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,6 +7,7 @@ import logging
 import subprocess
 from types import SimpleNamespace
 
+import pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
@@ -26,6 +27,46 @@ KAFKA_CHANNEL = "3/edge"
 DEFAULT_NUM_UNITS = 2
 K8S_DB_MODEL_NAME = "database"
 MICROK8S_CLOUD_NAME = "uk8s"
+
+
+DEPLOY_MARKS = [
+    (
+        pytest.param(
+            use_tls,
+            cloud,
+            id=str(use_tls) + f"-{cloud}",
+            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
+        )
+    )
+    for use_tls in [True, False]
+    for cloud in ["vm", MICROK8S_CLOUD_NAME]
+]
+
+K8S_MARKS = [
+    (
+        pytest.param(
+            use_tls,
+            cloud,
+            id=str(use_tls) + f"-{cloud}",
+            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
+        )
+    )
+    for use_tls in [True, False]
+    for cloud in [MICROK8S_CLOUD_NAME]
+]
+
+VM_MARKS = [
+    (
+        pytest.param(
+            use_tls,
+            cloud,
+            id=str(use_tls) + f"-{cloud}",
+            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
+        )
+    )
+    for use_tls in [True, False]
+    for cloud in ["vm"]
+]
 
 
 KRAFT_CONFIG = {

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -20,9 +20,12 @@ MICROK8S_CLOUD_NAME = "cloudk8s"
 CONFIG_OPTS = {"workload_name": "test_mode", "parallel_processes": 1}
 SERIES = "jammy"
 KAFKA = "kafka"
+KAFKA_K8S = "kafka-k8s"
 APP_NAME = "kafka-benchmark"
 KAFKA_CHANNEL = "3/edge"
 DEFAULT_NUM_UNITS = 2
+K8S_DB_MODEL_NAME = "database"
+MICROK8S_CLOUD_NAME = "uk8s"
 
 
 KRAFT_CONFIG = {

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -127,8 +127,8 @@ async def test_build_and_deploy_k8s_only(
         await model_db.consume(f"admin/{ops_test.model.name}.certificates")
         await model_db.integrate("certificates", f"{KAFKA_K8S}:certificates")
 
-    await model_db.wait_for_idle(apps=[KAFKA_K8S], status="active", timeout=2000)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="waiting", timeout=2000)
+    await model_db.wait_for_idle(apps=[KAFKA_K8S], status="active", timeout=2000)
 
     assert len(ops_test.model.applications[APP_NAME].units) == DEFAULT_NUM_UNITS
     await controller.disconnect()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -13,14 +13,16 @@ from .helpers import (
     APP_NAME,
     CONFIG_OPTS,
     DEFAULT_NUM_UNITS,
+    DEPLOY_MARKS,
     K8S_DB_MODEL_NAME,
+    K8S_MARKS,
     KAFKA,
     KAFKA_CHANNEL,
     KAFKA_K8S,
     KRAFT_CONFIG,
-    MICROK8S_CLOUD_NAME,
     MODEL_CONFIG,
     SERIES,
+    VM_MARKS,
     check_service,
     get_leader_unit_id,
     run_action,
@@ -30,46 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 model_db = None
-
-
-DEPLOY_MARKS = [
-    (
-        pytest.param(
-            use_tls,
-            cloud,
-            id=str(use_tls) + f"-{cloud}",
-            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
-        )
-    )
-    for use_tls in [True, False]
-    for cloud in ["vm", MICROK8S_CLOUD_NAME]
-]
-
-K8S_MARKS = [
-    (
-        pytest.param(
-            use_tls,
-            cloud,
-            id=str(use_tls) + f"-{cloud}",
-            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
-        )
-    )
-    for use_tls in [True, False]
-    for cloud in [MICROK8S_CLOUD_NAME]
-]
-
-VM_MARKS = [
-    (
-        pytest.param(
-            use_tls,
-            cloud,
-            id=str(use_tls) + f"-{cloud}",
-            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
-        )
-    )
-    for use_tls in [True, False]
-    for cloud in ["vm"]
-]
 
 
 @pytest.mark.parametrize("use_tls,cloud", K8S_MARKS)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -109,7 +109,7 @@ async def test_build_and_deploy_k8s_only(
         application_name=KAFKA_K8S,
     )
     await ops_test.model.consume(f"admin/{model_db.name}.kafka-client")
-    await ops_test.model.integrate("kafka-client", kafka_benchmark_charm)
+    await ops_test.model.integrate("kafka-client", f"{APP_NAME}:kafka")
 
     if use_tls:
         await ops_test.model.deploy(
@@ -117,7 +117,7 @@ async def test_build_and_deploy_k8s_only(
             num_units=1,
             series=SERIES,
         )
-        await ops_test.model.integrate(kafka_benchmark_charm, "self-signed-certificates")
+        await ops_test.model.integrate(APP_NAME, "self-signed-certificates")
 
         await ops_test.model.create_offer(
             endpoint="certificates",
@@ -125,7 +125,7 @@ async def test_build_and_deploy_k8s_only(
             application_name="self-signed-certificates",
         )
         await model_db.consume(f"admin/{ops_test.model.name}.certificates")
-        await ops_test.model.integrate("certificates", KAFKA_K8S)
+        await ops_test.model.integrate("certificates", f"{KAFKA_K8S}:certificates")
 
     await model_db.wait_for_idle(apps=[KAFKA_K8S], status="active", timeout=2000)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="waiting", timeout=2000)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,6 +4,7 @@
 
 import logging
 
+import juju
 import pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
@@ -12,9 +13,12 @@ from .helpers import (
     APP_NAME,
     CONFIG_OPTS,
     DEFAULT_NUM_UNITS,
+    K8S_DB_MODEL_NAME,
     KAFKA,
+    KAFKA_K8S,
     KAFKA_CHANNEL,
     KRAFT_CONFIG,
+    MICROK8S_CLOUD_NAME,
     MODEL_CONFIG,
     SERIES,
     check_service,
@@ -25,23 +29,118 @@ from .helpers import (
 logger = logging.getLogger(__name__)
 
 
-TLS_MARK = {
-    (use_tls): pytest.param(
-        use_tls,
-        id=str(use_tls),
-        marks=[
-            pytest.mark.group(str(use_tls)),
-        ],
+model_db = None
+
+
+DEPLOY_MARKS = [
+    (
+        pytest.param(
+            use_tls,
+            cloud,
+            id=str(use_tls) + f"-{cloud}",
+            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
+        )
     )
     for use_tls in [True, False]
-}
-USE_TLS = list(TLS_MARK.values())
+    for cloud in ["vm", MICROK8S_CLOUD_NAME]
+]
+
+K8S_MARKS = [
+    (
+        pytest.param(
+            use_tls,
+            cloud,
+            id=str(use_tls) + f"-{cloud}",
+            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
+        )
+    )
+    for use_tls in [True, False]
+    for cloud in [MICROK8S_CLOUD_NAME]
+]
+
+VM_MARKS = [
+    (
+        pytest.param(
+            use_tls,
+            cloud,
+            id=str(use_tls) + f"-{cloud}",
+            marks=pytest.mark.group(str(use_tls) + f"-{cloud}"),
+        )
+    )
+    for use_tls in [True, False]
+    for cloud in ["vm"]
+]
 
 
-@pytest.mark.parametrize("use_tls", USE_TLS)
+@pytest.mark.parametrize("use_tls,cloud", K8S_MARKS)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_deploy(ops_test: OpsTest, kafka_benchmark_charm, use_tls) -> None:
+async def test_build_and_deploy_k8s_only(
+    ops_test: OpsTest, microk8s, kafka_benchmark_charm, use_tls, cloud
+) -> None:
+    """Build and deploy with and without TLS on k8s."""
+    logging.info(f"Creating k8s model {K8S_DB_MODEL_NAME}")
+    controller = juju.controller.Controller()
+    await controller.connect()
+    await controller.add_model(K8S_DB_MODEL_NAME, cloud_name=microk8s.cloud_name)
+
+    global model_db
+    model_db = juju.model.Model()
+    await model_db.connect(model_name=K8S_DB_MODEL_NAME)
+
+    await ops_test.model.set_config(MODEL_CONFIG)
+    await ops_test.model.deploy(
+        kafka_benchmark_charm,
+        num_units=DEFAULT_NUM_UNITS,
+        series=SERIES,
+        config=CONFIG_OPTS,
+    )
+    await model_db.deploy(
+        KAFKA_K8S,
+        channel=KAFKA_CHANNEL,
+        config=KRAFT_CONFIG,
+        num_units=DEFAULT_NUM_UNITS,
+        series=SERIES,
+        trust=True,
+    )
+    await model_db.create_offer(
+        endpoint="kafka-client",
+        offer_name="kafka-client",
+        application_name=KAFKA_K8S,
+    )
+    await ops_test.model.consume(f"admin/{model_db.name}.kafka-client")
+    await ops_test.model.integrate(f"admin/{model_db.name}.kafka-client", kafka_benchmark_charm)
+
+    if use_tls:
+        await ops_test.model.deploy(
+            "self-signed-certificates",
+            num_units=1,
+            series=SERIES,
+        )
+        await ops_test.model.integrate(kafka_benchmark_charm, "self-signed-certificates")
+
+        await ops_test.model.create_offer(
+            endpoint="certificates",
+            offer_name="certificates",
+            application_name="self-signed-certificates",
+        )
+        await model_db.consume(f"admin/{ops_test.model.name}.certificates")
+        await ops_test.model.integrate(f"admin/{ops_test.model.name}.certificates", KAFKA_K8S)
+
+    await model_db.wait_for_idle(apps=[KAFKA_K8S], status="active", timeout=2000)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="waiting", timeout=2000)
+
+    assert len(ops_test.model.applications[APP_NAME].units) == DEFAULT_NUM_UNITS
+    await controller.disconnect()
+    await model_db.disconnect()
+
+
+@pytest.mark.parametrize("use_tls,cloud", VM_MARKS)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy_vm_only(
+    ops_test: OpsTest, kafka_benchmark_charm, use_tls, cloud
+) -> None:
     """Build and deploy with and without TLS."""
     await ops_test.model.set_config(MODEL_CONFIG)
 
@@ -73,10 +172,14 @@ async def test_deploy(ops_test: OpsTest, kafka_benchmark_charm, use_tls) -> None
 
     assert len(ops_test.model.applications[APP_NAME].units) == DEFAULT_NUM_UNITS
 
+    # set the model to the global model_db
+    global model_db
+    model_db = ops_test.model
 
-@pytest.mark.parametrize("use_tls", USE_TLS)
+
+@pytest.mark.parametrize("use_tls,cloud", DEPLOY_MARKS)
 @pytest.mark.abort_on_fail
-async def test_prepare(ops_test: OpsTest, use_tls) -> None:
+async def test_prepare(ops_test: OpsTest, use_tls, cloud) -> None:
     """Test prepare action."""
     leader_id = await get_leader_unit_id(ops_test)
 
@@ -93,9 +196,9 @@ async def test_prepare(ops_test: OpsTest, use_tls) -> None:
     )
 
 
-@pytest.mark.parametrize("use_tls", USE_TLS)
+@pytest.mark.parametrize("use_tls,cloud", DEPLOY_MARKS)
 @pytest.mark.abort_on_fail
-async def test_run(ops_test: OpsTest, use_tls) -> None:
+async def test_run(ops_test: OpsTest, use_tls, cloud) -> None:
     """Test run action."""
     leader_id = await get_leader_unit_id(ops_test)
 
@@ -111,9 +214,9 @@ async def test_run(ops_test: OpsTest, use_tls) -> None:
     assert check_service("dpe_benchmark", unit_id=leader_id)
 
 
-@pytest.mark.parametrize("use_tls", USE_TLS)
+@pytest.mark.parametrize("use_tls,cloud", DEPLOY_MARKS)
 @pytest.mark.abort_on_fail
-async def test_stop(ops_test: OpsTest, use_tls) -> None:
+async def test_stop(ops_test: OpsTest, use_tls, cloud) -> None:
     """Test stop action."""
     leader_id = await get_leader_unit_id(ops_test)
 
@@ -129,9 +232,9 @@ async def test_stop(ops_test: OpsTest, use_tls) -> None:
     assert not check_service("dpe_benchmark", unit_id=leader_id)
 
 
-@pytest.mark.parametrize("use_tls", USE_TLS)
+@pytest.mark.parametrize("use_tls,cloud", DEPLOY_MARKS)
 @pytest.mark.abort_on_fail
-async def test_restart(ops_test: OpsTest, use_tls) -> None:
+async def test_restart(ops_test: OpsTest, use_tls, cloud) -> None:
     """Test stop and restart the benchmark."""
     leader_id = await get_leader_unit_id(ops_test)
 
@@ -147,9 +250,9 @@ async def test_restart(ops_test: OpsTest, use_tls) -> None:
     assert check_service("dpe_benchmark", unit_id=leader_id)
 
 
-@pytest.mark.parametrize("use_tls", USE_TLS)
+@pytest.mark.parametrize("use_tls,cloud", DEPLOY_MARKS)
 @pytest.mark.abort_on_fail
-async def test_clean(ops_test: OpsTest, use_tls) -> None:
+async def test_clean(ops_test: OpsTest, use_tls, cloud) -> None:
     """Test cleanup action."""
     leader_id = await get_leader_unit_id(ops_test)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,8 +15,8 @@ from .helpers import (
     DEFAULT_NUM_UNITS,
     K8S_DB_MODEL_NAME,
     KAFKA,
-    KAFKA_K8S,
     KAFKA_CHANNEL,
+    KAFKA_K8S,
     KRAFT_CONFIG,
     MICROK8S_CLOUD_NAME,
     MODEL_CONFIG,
@@ -98,7 +98,7 @@ async def test_build_and_deploy_k8s_only(
     await model_db.deploy(
         KAFKA_K8S,
         channel=KAFKA_CHANNEL,
-        config=KRAFT_CONFIG,
+        config=KRAFT_CONFIG | {"expose_external": "nodeport"},
         num_units=DEFAULT_NUM_UNITS,
         series=SERIES,
         trust=True,
@@ -109,7 +109,7 @@ async def test_build_and_deploy_k8s_only(
         application_name=KAFKA_K8S,
     )
     await ops_test.model.consume(f"admin/{model_db.name}.kafka-client")
-    await ops_test.model.integrate(f"admin/{model_db.name}.kafka-client", kafka_benchmark_charm)
+    await ops_test.model.integrate("kafka-client", kafka_benchmark_charm)
 
     if use_tls:
         await ops_test.model.deploy(
@@ -125,7 +125,7 @@ async def test_build_and_deploy_k8s_only(
             application_name="self-signed-certificates",
         )
         await model_db.consume(f"admin/{ops_test.model.name}.certificates")
-        await ops_test.model.integrate(f"admin/{ops_test.model.name}.certificates", KAFKA_K8S)
+        await ops_test.model.integrate("certificates", KAFKA_K8S)
 
     await model_db.wait_for_idle(apps=[KAFKA_K8S], status="active", timeout=2000)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="waiting", timeout=2000)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -125,7 +125,7 @@ async def test_build_and_deploy_k8s_only(
             application_name="self-signed-certificates",
         )
         await model_db.consume(f"admin/{ops_test.model.name}.certificates")
-        await ops_test.model.integrate("certificates", f"{KAFKA_K8S}:certificates")
+        await model_db.integrate("certificates", f"{KAFKA_K8S}:certificates")
 
     await model_db.wait_for_idle(apps=[KAFKA_K8S], status="active", timeout=2000)
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="waiting", timeout=2000)


### PR DESCRIPTION
This PR extends the integration testing to also cover kafka k8s charm. It tests both with and without TLS.

It also fixes an issue between a VM-based benchmark related to a k8s-based broker: we get the incorrect number of brokers as we only see a single endpoint - the nodeport one.

This PR extends the Kafka client lib to then expose the brokers' metadata. With that metadata, we can recover the correct number of brokers in both VM and k8s based deployments instead.